### PR TITLE
Feature/node children

### DIFF
--- a/example_child.py
+++ b/example_child.py
@@ -1,0 +1,120 @@
+import panel as pn
+
+import panel.custom
+import panel.viewable
+
+
+import src.reactflow as rf
+
+
+nodes_full = [
+    {
+        "id": "1",
+        "position": {"x": 0, "y": 0},
+        "data": {
+            "label": "node 1",
+        },
+        "panes": pn.Column(
+            pn.widgets.TextInput(name="Name", placeholder="Enter name..."),
+            pn.widgets.Select(name='Select', 
+                              options=['Biology', 'Chemistry', 'Physics']),
+        ),
+    },
+    {
+        "id": "2",
+        "position": {"x": 0, "y": 100},
+        "data": {
+            "label": "node 2",
+        },
+        "panes": pn.Column(
+            pn.widgets.TextInput(name="Name", placeholder="Enter name..."),
+            pn.widgets.Select(name='Select', 
+                              options=['Math', 'English']),
+        ),
+    },
+    {
+        "id": "3",
+        "position": {"x": 0, "y": 100},
+        "data": {
+            "label": "node 3",
+        },
+    },
+    {
+        "id": "4",
+        "position": {"x": 0, "y": 100},
+        "panes": pn.Column(
+            pn.widgets.TextInput(name="Name", placeholder="Enter name..."),
+            pn.widgets.Select(name='Select', 
+                              options=['Chem', 'History']),
+        ),
+    },
+]
+
+common_edge_props = {
+    "markerEnd": {"type": "arrowclosed"},
+    "style": {"strokeWidth": 3},
+    "deletable": True,
+}
+
+
+"""
+nodes = []
+node_panes = []
+for i, n in enumerate(nodes_full):
+    node_panes.append(n.pop("panes"))
+
+    if "data" in n:
+        n["data"]["pane_index"] = i
+    else:
+        n["data"] = {"pane_index": i}
+    n["type"] = "custom"
+    nodes.append(n)
+"""
+
+def my_fun(x):
+    print(x)
+
+# node_panes[0].objects[0].param.watch(my_fun, "value")
+
+
+app = rf.ReactFlowComponent(
+    nodes=nodes_full,
+    edges=[],
+    height=1600,
+    sizing_mode="stretch_width",
+    default_edge_options=common_edge_props,
+    stylesheets=[
+        """
+        .react-flow__node.selected {
+            background-color: coral;
+            border: 2px solid black;
+        }
+
+        .react-flow__node {
+            background-color: white;
+            border: 2px solid #777;
+            border-radius: 10px;
+        }
+
+        """.strip(),
+        # """
+        # /* 1. Define a default background for the child, using a variable. */
+        # .bk-Column {
+        #     background-color: var(--node-bg-color, white);
+        #     border-radius: inherit; /* Make child corners match parent's corners */
+        #     width: 100%;
+        #     height: 100%;
+        # }
+
+        # /* 2. When the parent node is selected, change the VALUE of the variable. */
+        # .react-flow__node.selected {
+        #     --node-bg-color: #FFDAB9; /* A pleasant light coral/peach color */
+        #     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+        # }
+        # """,
+    ],
+)
+
+pn.Row(
+    app,
+).servable()

--- a/src/reactflow.js
+++ b/src/reactflow.js
@@ -30,9 +30,6 @@ function CustomNode({ data }) {
       <Handle type="target" position={Position.Left} />
       <div style={{
         padding: '10px',
-        border: '1px solid #777',
-        borderRadius: '5px',
-        background: '#fff',
         minWidth: '150px',
       }}>
         <h3>{data.label}</h3>

--- a/src/reactflow.js
+++ b/src/reactflow.js
@@ -3,6 +3,7 @@ import {
   useState,
   useRef,
   useEffect,
+  useMemo,
 } from 'react';
 import { 
   ReactFlow,
@@ -11,6 +12,8 @@ import {
   Background,
   MiniMap,
   MarkerType,
+  Handle,
+  Position,
   // applyNodeChanges,
   // applyEdgeChanges,
   addEdge,
@@ -18,13 +21,48 @@ import {
   useEdgesState,
 } from '@xyflow/react';
 
+
+// 1. Create the CustomNode component
+// This component will receive the rendered Panel child via props.data.panel_child
+function CustomNode({ data }) {
+  return (
+    <>
+      <Handle type="target" position={Position.Left} />
+      <div style={{
+        padding: '10px',
+        border: '1px solid #777',
+        borderRadius: '5px',
+        background: '#fff',
+        minWidth: '150px',
+      }}>
+        <h3>{data.label}</h3>
+        {data.pane_component}
+      </div>
+      <Handle type="source" position={Position.Right} />
+    </>
+  );
+}
+
 export function render({ model }) {
 
-  // console.log("rendering...")
-  const [py_nodes, setPyNodes] = model.useState('nodes');
+  const nodeTypes = useMemo(() => ({ custom: CustomNode }), []);
+
+  const node_panes = model.get_child('panel_nodes');
+  const [py_nodes, setPyNodes] = model.useState('reactflow_nodes');
   const [py_edges, setPyEdges] = model.useState('edges');
   const [defaultEdgeOptions] = model.useState('default_edge_options');
-  const [nodes, setNodes, onNodesChange] = useNodesState(py_nodes);
+
+  const processed_nodes = useMemo(() =>
+    py_nodes.map(node => ({
+      ...node,
+      data: {
+        ...node.data,
+        pane_component: node_panes[node.data.pane_index],
+      },
+    })), [py_nodes, node_panes]);
+
+  // const [nodes, setNodes, onNodesChange] = useNodesState(py_nodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState(processed_nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(py_edges);
 
   // ref for latest nodes and edges
@@ -36,12 +74,17 @@ export function render({ model }) {
   useEffect(() => { edgesRef.current = edges; }, [edges]);
 
   // sync changes from python to local
-  useEffect(() => { setNodes(py_nodes); }, [py_nodes, setNodes]);
+  useEffect(() => { setNodes(processed_nodes); }, [processed_nodes, setNodes]);
   useEffect(() => { setEdges(py_edges); }, [py_edges, setEdges]);
 
   // Sync change from local to python
   const syncToPython = useCallback(() => {
-    setPyNodes(nodesRef.current);
+    const nodesToSync = nodesRef.current.map(({ data, ...rest }) => {
+      const { pane_component, ...serializableData } = data;
+      return { ...rest, data: serializableData };
+    });
+    // setPyNodes(nodesRef.current);
+    setPyNodes(nodesToSync);
     setPyEdges(edgesRef.current);
   }, [setPyNodes, setPyEdges]);
 
@@ -60,6 +103,7 @@ export function render({ model }) {
           nodes={nodes}
           edges={edges}
           defaultEdgeOptions={defaultEdgeOptions}
+          nodeTypes={nodeTypes}
 
           // Local state
           onNodesChange={onNodesChange}


### PR DESCRIPTION
* allow nodes to have viewable panes (ie anything that works with `model.get_child` https://panel.holoviz.org/reference/custom_components/ReactComponent.html#displaying-a-list-of-children)
* nodes are provided as a list of dicts and there is a special keyword "panes" which stores the expected pane. The rest of the node structure is per reactflow.dev